### PR TITLE
widening the popup box

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,4 @@
+body {
+  max-height: 300px;
+  min-width: 800px;
+}

--- a/popup.html
+++ b/popup.html
@@ -3,8 +3,9 @@
   <head>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="popup.js"></script>
+    <link rel="stylesheet" href="popup.css">
   </head>
   <body>
-    <span id="pizzaInfo"></span>
+    <div id="pizzaInfo"></div>
   </body>
 </html>


### PR DESCRIPTION
By making changes to the css and html, I was able to stretch and shorten the pop up being presented when the user clicks the extension icon. It was previously very thin and long in a way that was very unattractive.

This PR will resolve issue #2 by:
- changing a span to a div (which very possibly did not make any difference for this issue but I believe is more appropriate than span so I think it ends up being a worthwhile change anyway)
- adding a css file that specifies the width and height of the popup body
